### PR TITLE
ci: use self-hosted runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: "⬇️ Checkout"
         uses: actions/checkout@v4


### PR DESCRIPTION
Replace compatible GitHub-hosted runner selections with the self-hosted runner.